### PR TITLE
Wallet UI improvements

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -10,28 +10,27 @@
     <height>342</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="topLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_6">
    <item>
-    <widget class="QLabel" name="labelAlerts">
-     <property name="visible">
-      <bool>false</bool>
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
+     <property name="spacing">
+      <number>6</number>
      </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000;</string>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="topMargin">
+      <number>12</number>
      </property>
-     <property name="margin">
-      <number>3</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
@@ -111,31 +110,6 @@
             <property name="spacing">
              <number>12</number>
             </property>
-            <item row="2" column="2">
-             <widget class="QLabel" name="labelWatchPending">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
-              </property>
-              <property name="toolTip">
-               <string>Unconfirmed transactions to watch-only addresses</string>
-              </property>
-              <property name="text">
-               <string notr="true">0.000 000 00 ERC</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
             <item row="2" column="1">
              <widget class="QLabel" name="labelUnconfirmed">
               <property name="font">
@@ -256,6 +230,31 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="labelWatchPending">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="cursor">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>Unconfirmed transactions to watch-only addresses</string>
+              </property>
+              <property name="text">
+               <string notr="true">0.000 000 00 ERC</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
             </item>
             <item row="3" column="0">
              <widget class="QLabel" name="labelImmatureText">
@@ -519,10 +518,13 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Maximum</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>10</width>
+           <height>10</height>
           </size>
          </property>
         </spacer>
@@ -550,7 +552,10 @@
       <bool>true</bool>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>75</number>
+      <number>85</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+       <bool>true</bool>
      </attribute>
      <column>
       <property name="text">
@@ -626,7 +631,176 @@
      </column>
     </widget>
    </item>
+   <item>
+    <widget class="QFrame" name="frame_3">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0" columnstretch="0,0,0,0,0,0,0" rowminimumheight="0,0,0" columnminimumwidth="0,0,0,0,0,0,0">
+        <property name="spacing">
+         <number>12</number>
+        </property>
+        <item row="2" column="0">
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="4">
+         <widget class="QLabel" name="labelMaturedText">
+          <property name="text">
+           <string>Matured:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="5">
+         <widget class="QLabel" name="labelMatured">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="cursor">
+           <cursorShape>IBeamCursor</cursorShape>
+          </property>
+          <property name="toolTip">
+           <string>Your total balance of matured deposits that are currently not earning any interest.</string>
+          </property>
+          <property name="text">
+           <string notr="true">0.000 000 00 ERC</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="6">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labellockedtext">
+          <property name="text">
+           <string>Locked:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="labelaccruedtext">
+          <property name="text">
+           <string>Accrued:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="labellocked">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="cursor">
+           <cursorShape>IBeamCursor</cursorShape>
+          </property>
+          <property name="toolTip">
+           <string>Your total locked/invested balance in term deposits.</string>
+          </property>
+          <property name="text">
+           <string notr="true">0.000 000 00 ERC</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QLabel" name="labelaccrued">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="cursor">
+           <cursorShape>IBeamCursor</cursorShape>
+          </property>
+          <property name="toolTip">
+           <string>Your total balance of accrued interests, that have not matured yet.</string>
+          </property>
+          <property name="text">
+           <string notr="true">0.000 000 00 ERC</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
+  <widget class="QLabel" name="labelAlerts">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+      <string notr="true">background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000;</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+   <property name="margin">
+    <number>3</number>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections/>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -15,6 +15,7 @@
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
 #include "wallet/wallet.h"
+#include "util.h"
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
@@ -174,6 +175,10 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     bool showImmature = immatureBalance != 0;
     bool showWatchOnlyImmature = watchImmatureBalance != 0;
 
+    // Fetch sort flag
+    bool sort_flag = GetArg("-sort", true);
+    LogPrintf("sort flag = %b\n", sort_flag);
+
     // for symmetry reasons also show immature label when the watch-only one is shown
     ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
     ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
@@ -184,8 +189,12 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
 
     // actually update labels
     int nDisplayUnit = BitcoinUnits::ERC;
-    //if (model && model->getOptionsModel())
-    //    nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
+    // Disable sorting outside the for loop
+    ui->hodlTable->setSortingEnabled(false);
+
+    uint64_t totalLocked  = 0;
+    uint64_t totalAccrued = 0;
+    uint64_t totalMatured = 0;
 
     for(int i=0;i<termDepositInfo.size();i++){
         COutput ctermDeposit=termDepositInfo[i];
@@ -204,8 +213,11 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         double interestRate=(pow(interestRatePerBlock,365*288)-1)*100;
         if(curHeight>=releaseBlock){
             ui->hodlTable->setItem(i, 0, new QTableWidgetItem(QString("Matured (Warning: this amount is no longer earning interest of any kind)")));
+            totalMatured += matureValue;
         }else{
             ui->hodlTable->setItem(i, 0, new QTableWidgetItem(QString("locked")));
+            totalAccrued += (withInterest-termDeposit.nValue);
+            totalLocked  += termDeposit.nValue;
         }
         ui->hodlTable->setItem(i, 1, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, termDeposit.nValue)));
         ui->hodlTable->setItem(i, 2, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest-termDeposit.nValue)));
@@ -213,9 +225,15 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->hodlTable->setItem(i, 3, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest)));
         ui->hodlTable->setItem(i, 4, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, matureValue)));
         ui->hodlTable->setItem(i, 5, new QTableWidgetItem(QString::number((term)/288)));
-        ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight)));
-        ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock)));
-        //time_t releaseDate = time(0)+blocksRemaining*154;
+
+        if(!sort_flag){
+            ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight)));
+            ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock)));
+            //time_t releaseDate = time(0)+blocksRemaining*154;
+        }else{
+            ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight).rightJustified(7,'0')));
+            ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock).rightJustified(7,'0')));
+        }
 
         time_t rawtime;
         struct tm * timeinfo;
@@ -229,8 +247,14 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->hodlTable->setItem(i, 8, new QTableWidgetItem(QString(buffer)));
 
         //ui->hodlTable->setItem(i, 9, new QTableWidgetItem(QString::number(interestRatePerBlock)+QString("%")));
+    }
 
+    ui->labellocked->setText(BitcoinUnits::formatWithUnit(unit, totalLocked, false, BitcoinUnits::separatorAlways));
+    ui->labelaccrued->setText(BitcoinUnits::formatWithUnit(unit, totalAccrued, false, BitcoinUnits::separatorAlways));
+    ui->labelMatured->setText(BitcoinUnits::formatWithUnit(unit, totalMatured, false, BitcoinUnits::separatorAlways));
 
+    if(sort_flag){
+     ui->hodlTable->setSortingEnabled(true);
     }
 }
 


### PR DESCRIPTION
This pull request adds some useful wallet UI improvements, 

1- added new flag "sort" to enable/disable deposit table sorting. (default is enabled)
When sorting is enabled,  the block numbers will be right justified and padded with zero's to help with sorting as qt sort is only alphabetical.

2- added totals under the deposit table to help identify matured coins.
3- fixed last column expansion issue.

Screenshot of new look: http://i.imgur.com/noYNe3Z.jpg