### PR TITLE
properly clean all 3rd party compiler generated files

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -401,7 +401,11 @@ libbitcoinconsensus_la_CPPFLAGS = $(CRYPTO_CFLAGS) -I$(builddir)/obj -DBUILD_BIT
 endif
 #
 
-CLEANFILES = leveldb/libleveldb.a leveldb/libmemenv.a *.gcda *.gcno
+CLEANFILES = leveldb/libleveldb.a leveldb/libmemenv.a
+CLEANFILES += $(EXTRA_LIBRARIES)
+CLEANFILES += *.gcda *.gcno
+CLEANFILES += compat/*.gcda compat/*.gcno
+CLEANFILES += consensus/*.gcda consensus/*.gcno
 
 DISTCLEANFILES = obj/build.h
 


### PR DESCRIPTION
Improving "make clean" target to also handle 3rd party generated libraries.
